### PR TITLE
Replace gitkeep placeholders with Godot-visible text files

### DIFF
--- a/assets/audio/music/decades/1950s/placeholder.txt
+++ b/assets/audio/music/decades/1950s/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/audio/music/decades/1960s/placeholder.txt
+++ b/assets/audio/music/decades/1960s/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/audio/music/decades/1970s/placeholder.txt
+++ b/assets/audio/music/decades/1970s/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/audio/music/decades/1980s/placeholder.txt
+++ b/assets/audio/music/decades/1980s/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/audio/music/decades/1990s/placeholder.txt
+++ b/assets/audio/music/decades/1990s/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/audio/music/decades/2000s/placeholder.txt
+++ b/assets/audio/music/decades/2000s/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/audio/music/decades/2010s/placeholder.txt
+++ b/assets/audio/music/decades/2010s/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/audio/music/decades/2020s/placeholder.txt
+++ b/assets/audio/music/decades/2020s/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/audio/music/decades/placeholder.txt
+++ b/assets/audio/music/decades/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/audio/music/menu/placeholder.txt
+++ b/assets/audio/music/menu/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/audio/music/placeholder.txt
+++ b/assets/audio/music/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/audio/placeholder.txt
+++ b/assets/audio/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/audio/sfx/events/placeholder.txt
+++ b/assets/audio/sfx/events/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/audio/sfx/placeholder.txt
+++ b/assets/audio/sfx/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/audio/sfx/ui/placeholder.txt
+++ b/assets/audio/sfx/ui/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/fonts/decades/placeholder.txt
+++ b/assets/fonts/decades/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/fonts/placeholder.txt
+++ b/assets/fonts/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/fonts/ui/placeholder.txt
+++ b/assets/fonts/ui/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/backgrounds/events/placeholder.txt
+++ b/assets/graphics/backgrounds/events/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/backgrounds/offices/placeholder.txt
+++ b/assets/graphics/backgrounds/offices/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/backgrounds/placeholder.txt
+++ b/assets/graphics/backgrounds/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/icons/attributes/placeholder.txt
+++ b/assets/graphics/icons/attributes/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/icons/genres/placeholder.txt
+++ b/assets/graphics/icons/genres/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/icons/placeholder.txt
+++ b/assets/graphics/icons/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/icons/ui/placeholder.txt
+++ b/assets/graphics/icons/ui/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/placeholder.txt
+++ b/assets/graphics/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/portraits/npcs/directors/placeholder.txt
+++ b/assets/graphics/portraits/npcs/directors/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/portraits/npcs/journalists/placeholder.txt
+++ b/assets/graphics/portraits/npcs/journalists/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/portraits/npcs/placeholder.txt
+++ b/assets/graphics/portraits/npcs/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/portraits/npcs/studio_executives/placeholder.txt
+++ b/assets/graphics/portraits/npcs/studio_executives/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/portraits/placeholder.txt
+++ b/assets/graphics/portraits/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/portraits/talents/female/placeholder.txt
+++ b/assets/graphics/portraits/talents/female/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/portraits/talents/male/placeholder.txt
+++ b/assets/graphics/portraits/talents/male/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/portraits/talents/neutral/placeholder.txt
+++ b/assets/graphics/portraits/talents/neutral/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/portraits/talents/placeholder.txt
+++ b/assets/graphics/portraits/talents/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/ui/buttons/placeholder.txt
+++ b/assets/graphics/ui/buttons/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/ui/decorations/placeholder.txt
+++ b/assets/graphics/ui/decorations/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/ui/panels/placeholder.txt
+++ b/assets/graphics/ui/panels/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/graphics/ui/placeholder.txt
+++ b/assets/graphics/ui/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/placeholder.txt
+++ b/assets/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/text/localization/de/placeholder.txt
+++ b/assets/text/localization/de/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/text/localization/en/placeholder.txt
+++ b/assets/text/localization/en/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/text/localization/placeholder.txt
+++ b/assets/text/localization/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/text/narrative/dialogue/placeholder.txt
+++ b/assets/text/narrative/dialogue/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/text/narrative/events/placeholder.txt
+++ b/assets/text/narrative/events/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/text/narrative/news/placeholder.txt
+++ b/assets/text/narrative/news/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/text/narrative/placeholder.txt
+++ b/assets/text/narrative/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/assets/text/placeholder.txt
+++ b/assets/text/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/data/balancing/placeholder.txt
+++ b/data/balancing/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/data/databases/placeholder.txt
+++ b/data/databases/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/data/placeholder.txt
+++ b/data/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/data/templates/placeholder.txt
+++ b/data/templates/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/exports/placeholder.txt
+++ b/exports/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/saves/placeholder.txt
+++ b/saves/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scenes/placeholder.txt
+++ b/scenes/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scenes/systems/placeholder.txt
+++ b/scenes/systems/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scenes/ui/components/placeholder.txt
+++ b/scenes/ui/components/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scenes/ui/game_screens/placeholder.txt
+++ b/scenes/ui/game_screens/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scenes/ui/menus/placeholder.txt
+++ b/scenes/ui/menus/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scenes/ui/placeholder.txt
+++ b/scenes/ui/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scenes/ui/popups/placeholder.txt
+++ b/scenes/ui/popups/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scripts/core/placeholder.txt
+++ b/scripts/core/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scripts/data/database/placeholder.txt
+++ b/scripts/data/database/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scripts/data/managers/placeholder.txt
+++ b/scripts/data/managers/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scripts/data/models/placeholder.txt
+++ b/scripts/data/models/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scripts/data/placeholder.txt
+++ b/scripts/data/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scripts/gameplay/ai/placeholder.txt
+++ b/scripts/gameplay/ai/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scripts/gameplay/mechanics/placeholder.txt
+++ b/scripts/gameplay/mechanics/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scripts/gameplay/placeholder.txt
+++ b/scripts/gameplay/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scripts/placeholder.txt
+++ b/scripts/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scripts/systems/placeholder.txt
+++ b/scripts/systems/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scripts/ui/components/placeholder.txt
+++ b/scripts/ui/components/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scripts/ui/placeholder.txt
+++ b/scripts/ui/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scripts/ui/popups/placeholder.txt
+++ b/scripts/ui/popups/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scripts/ui/screens/placeholder.txt
+++ b/scripts/ui/screens/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.

--- a/scripts/utils/placeholder.txt
+++ b/scripts/utils/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file to ensure Godot recognizes this directory.


### PR DESCRIPTION
## Summary
- replace the previous `.gitkeep` placeholders with `placeholder.txt` files so Godot will display every directory in the project tree

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae16539e08323854bf0bae5f5148e